### PR TITLE
fix tag

### DIFF
--- a/liteloader-qqnt-lite-tools-bin/PKGBUILD
+++ b/liteloader-qqnt-lite-tools-bin/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname='liteloader-qqnt-lite-tools-bin'
 _pkgname='LiteLoaderQQNT-lite_tools'
-pkgver='2.31.0'
+pkgver=2.31.0 # renovate: datasource=github-tags depName=xiyuesaves/LiteLoaderQQNT-lite_tools
 pkgrel=1
 pkgdesc='LiteLoaderQQNT插件，轻量工具箱，轻量、优雅、高效'
 arch=('any')

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
         "(^|/)PKGBUILD$"
       ],
       "matchStrings": [
-        "pkgver=(?<currentValue>.*)"
+        "pkgver=(?<currentValue>.*) # renovate: datasource=(?<datasource>.*) depName=(?<depName>.*)"
       ],
       "extractVersionTemplate": "^v?(?<version>.*)$"
     }


### PR DESCRIPTION
自定义的PKGBUILD需要手动处理数据，为 renovate 标记数据；而 submodule 引入的包无需处理